### PR TITLE
Temp fix to stop hbInputGenerator from cycling

### DIFF
--- a/app/glyphpalette.py
+++ b/app/glyphpalette.py
@@ -66,7 +66,7 @@ class HtmlInputGenerator(HbInputGenerator):
 
         # check the substitution features
         inputs.extend(self._inputs_from_gsub(name, seen))
-        seen.remove(name)
+        # seen.remove(name)
 
         # since this method sometimes returns None to avoid cycles, the
         # recursive calls that it makes might have themselves returned None,


### PR DESCRIPTION
HbInputGenerator often gets stuck when building input combos for complex non-Latin fonts. This is a temporary fix, it needs further testing and also needs integrating into the nototools upstream.

This temp fix is needed asap in order to update several medium sized families.